### PR TITLE
Add new categories for boilerplates and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 [Awesome Stencil Articles](https://github.com/mappmechanic/awesome-stenciljs#awesome-articles-related)
 
+[Miscellaneous](#miscellaneous)
+
 
 ## What is StencilJS ?
 
@@ -67,6 +69,9 @@ An Awesome Talk to Know more about #StencilJS
 
 ### Visual Studio Code
 - [Stencil Snippets](https://github.com/Fdom92/stencil-snippets) - Stencil Snippets like st-component(generate component), st-prop(add new prop), st-event (add new @Event) etc.
+
+## Miscellaneous
+- [Stencil cheatsheet](https://devhints.io/stencil): Overview of Stencil best practices.
 
 ## Awesome Articles Related
 - [How Stencil Fit Into Micro Frontend Ideas](https://medium.com/@gilfink/avoiding-the-framework-catholic-wedding-using-stencil-compiler-3c2aa55bcaca) - An interesting read to know about usability of stenciljs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [Awesome Stencil Components](https://github.com/mappmechanic/awesome-stenciljs#list-of-awesome-components-made-using-stenciljs)
 
+[Boilerplates](#boilerplates-and-templates)
+
+[Tools](#tools)
+
 [Awesome IDE Plugins](https://github.com/mappmechanic/awesome-stenciljs#awesome-ide-specific-stencil-pluginssnippets)
 
 [Awesome Stencil Articles](https://github.com/mappmechanic/awesome-stenciljs#awesome-articles-related)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ An Awesome Talk to Know more about #StencilJS
 - [ST-Signature](https://github.com/gilf/st-signature): A Stencil component that allows the user to sign on screen and to get the bitmap of the signature.
 - [Web Audio](https://github.com/splitinfinities/web-audio-wc): Web Audio API as a set of web components! Provides `<web-audio>`, `<web-audio-source>`, `<web-audio-effect>`, `<web-audio-visualizer>`, `<web-audio-sequencer>`, and `<web-audio-debugger>`. 
 
+## Boilerplates and templates
+
+### Ionic official
+- [Stencil Component Starter](https://github.com/ionic-team/stencil-component-starter): Minimal boilerplate to create Stencil components.
+- [Stencil App Starter](https://github.com/ionic-team/stencil-app-starter): Basic boilerplate for Stencil components or apps.
+- [Ionic PWA Toolkit Beta](https://github.com/ionic-team/ionic-pwa-toolkit): Great starter template for building true PWAs with the power of Ionic and StencilJS.
+
+## Tools (CLIs, scripts, etc.)
+
+### Ionic official
+- [Create Stencil](https://github.com/ionic-team/create-stencil): A simple but effective npm script to start off a StencilJS project. Useful for complete apps, not just components. Uses the above starter packs [Boilerplates](#boilerplates-and-templates)
 
 ## Awesome IDE Specific Stencil Plugins/Snippets
 


### PR DESCRIPTION
New categories:

* Boilerplates and templates
There will probably be plenty of boilerplates and templates soon. I added a few official ones by the Ionic team.

* Tools
CLIs and script are very popular, therefore they deserve a separate category.